### PR TITLE
Fix package name regex

### DIFF
--- a/docs/homework.html
+++ b/docs/homework.html
@@ -55,7 +55,7 @@ Here is an example repository description:
 It consists of a list of objects, in the <a href="https://www.json.org/">JSON format</a>.
 Each object represents a package, using the following fields:
 <ul>
-<li><i>name</i>: string of letters from <tt>[a-zA-Z0-9-]</tt>
+<li><i>name</i>: string of letters from <tt>[.+a-zA-Z0-9-]</tt>
 <li><i>version</i>: list of nonnegative integers separated by dots (as a JSON string, with double-quotes around it)
 </ul>
 


### PR DESCRIPTION
Some packages in the tests have a "." and "+" in their name (e.g. linux-source-2.6.30rxart+exomate.1.2).